### PR TITLE
Ford 116/ polylang support

### DIFF
--- a/admin/class-wa-external-header-v2-admin.php
+++ b/admin/class-wa-external-header-v2-admin.php
@@ -57,6 +57,19 @@ class Wa_External_Header_V2_Admin {
 
 	}
 
+	public static function languagesIsEnabled()
+	{
+		return function_exists('Pll') && PLL()->model->get_languages_list();
+	}
+
+	public function getLanguages()
+	{
+		if (self::languagesIsEnabled()) {
+			return PLL()->model->get_languages_list();
+		}
+		return false;
+	}
+
 	/**
 	 * Register the stylesheets for the admin area.
 	 *
@@ -304,6 +317,15 @@ class Wa_External_Header_V2_Admin {
 	}
 
 	private function build_settings_field($option_key) {
+		if(self::languagesIsEnabled()){
+			$fields = '';
+			foreach($this->getLanguages() as $language){
+				$options = get_option( $this->options_group_name );
+				$value = (isset($options[$option_key. '_' . $language->locale]) ? $options[$option_key . '_' . $language->locale] : '');
+				 $fields .= $language->flag.'&nbsp;<input type="text" name="' . $this->options_group_name . '['. $option_key. '_' . $language->locale .']" value="' . $value . '"><br />';
+			}
+			return $fields;
+		}
 		$options = get_option( $this->options_group_name );
 		$value = (isset($options[$option_key]) ? $options[$option_key] : '');
 
@@ -311,6 +333,17 @@ class Wa_External_Header_V2_Admin {
 	}
 
 	private function build_settings_checkbox($option_key) {
+		if(self::languagesIsEnabled()){
+			$fields = '';
+			foreach($this->getLanguages() as $language){
+				$options = get_option( $this->options_group_name );
+				$value = (isset($options[$option_key. '_' . $language->locale]) ? $options[$option_key . '_' . $language->locale] : '');
+				$checked = ($value == 'true') ? 'checked="checked"' : '';
+
+				$fields .= $language->flag.'&nbsp;<input type="checkbox" value="true" name="' . $this->options_group_name . '['. $option_key. '_' . $language->locale .']" '.$checked.'><br />';
+			}
+			return $fields;
+		}
 		$options = get_option( $this->options_group_name );
 		$value = (isset($options[$option_key]) ? $options[$option_key] : '');
 
@@ -320,6 +353,22 @@ class Wa_External_Header_V2_Admin {
 	}
 
 	private function build_settings_dropdown($option_key,$dropdown_options){
+		if(self::languagesIsEnabled()){
+			$fields = '';
+			foreach($this->getLanguages() as $language){
+				$options = get_option( $this->options_group_name );
+				$dropdown_output = '<select name="'.$this->options_group_name.'['. $option_key . '_' . $language->locale.']">';
+
+				foreach($dropdown_options as $dropdown_key => $dropdown_value){
+					$selected = ($options[$option_key. '_' . $language->locale] === $dropdown_value) ? 'selected' : '';
+					$dropdown_output .= $language->flag.'&nbsp;<option value="'.$dropdown_value.'" '.$selected.'>'.$dropdown_key.'</option>';
+				}
+
+				$dropdown_output .= "</select>";
+				$fields .= $dropdown_output;
+			}
+			return $fields;
+		}
 		$options = get_option( $this->options_group_name );
 		$dropdown_output = '<select name="'.$this->options_group_name.'['. $option_key .']">';
 

--- a/public/class-wa-external-header-v2-public.php
+++ b/public/class-wa-external-header-v2-public.php
@@ -118,9 +118,6 @@ class Wa_External_Header_V2_Public
             $this->start_tag = print_r($wa_content->html->start_tag, true);
             $this->end_tag = print_r($wa_content->html->end_tag, true);
             $this->head = print_r($wa_content->html->head, true);
-            // preg_match("/^(.*)(<header .*)$/s", $wa_content->html->body->header, $siteHeader);
-            // print_r($wa_content->html->body);
-            // $this->afubar = $siteHeader[1];
             $this->header = $wa_content->html->body->header;
             $this->footer = print_r($wa_content->html->body->footer, true);
             $this->banners = print_r($wa_content->html->ad, true);

--- a/wa-external-header-v2.php
+++ b/wa-external-header-v2.php
@@ -16,7 +16,7 @@
  * Plugin Name:       WhiteAlbum External Header shell v2
  * Plugin URI:         bonnier.dk
  * Description:       Co-branding/shell integration for WordPress sites collaborating commercially with Bonnier Media AS
- * Version:           3.0.0
+ * Version:           0.1.3
  * Author:            Bonnier Interactive
  * Author URI:        bonnier.dk
  * License:           GPL-2.0+
@@ -66,9 +66,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-wa-external-header-v2.php'
  *
  * @since    1.0.0
  */
-function run_wa_external_header_v2() {
-
+add_action('plugins_loaded', function(){
 	$plugin = new Wa_External_Header_V2();
 	$plugin->run();
-}
-run_wa_external_header_v2();
+}, 100);


### PR DESCRIPTION
+ ### changed version number to match the real version numbers we use in our releases.
+ made the plugin run after plugins are loaded, not before
+ enabled multi language support and created a unified way of fetching options for sites with languages, and those without
+ enabled checks for languages in the backend